### PR TITLE
perf(home): mobile-first gating of decorative animations

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -24,6 +24,7 @@ import {
   Send,
   Stamp,
 } from 'lucide-react'
+import { useFxLevel } from '../hooks/useFxLevel'
 
 // ============================================================
 // Morse code (A–Z + 0–9) — for the live callsign preview
@@ -192,7 +193,10 @@ function SignalBars({ n = 5, active = true }: { n?: number; active?: boolean }) 
 
 function Waveform({ amplitude }: { amplitude: number }) {
   const reduce = useReducedMotion()
-  const bars = 40
+  const { isMobile } = useFxLevel()
+  // Halve bar count on mobile — 40 concurrent infinite framer-motion height
+  // animations is the kind of thing phones really feel.
+  const bars = isMobile ? 20 : 40
   return (
     <div
       aria-hidden

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -29,6 +29,7 @@ import { Marquee } from './ui/Marquee'
 import { AnimatedNumber } from './ui/AnimatedNumber'
 import { MagneticButton } from './ui/MagneticButton'
 import { NodeNetwork } from './ui/NodeNetwork'
+import { useFxLevel } from '../hooks/useFxLevel'
 
 const TECH_STACK = [
   'TypeScript',
@@ -148,12 +149,15 @@ export function Intro() {
       `radial-gradient(600px circle at ${x}px ${y}px, hsl(var(--accent) / 0.14), transparent 55%)`
   )
   const [aiHover, setAiHover] = useState(false)
+  const { isMobile, reduceMotion, disableHeavyFx } = useFxLevel()
 
-  // boot-line typewriter
+  // boot-line typewriter — show fully typed instantly on mobile / reduce-motion.
+  // The 55ms cadence is satisfying on a 60Hz desktop but adds ~1.4s of
+  // useless re-renders on first paint for phone users who can't even see
+  // the cursor blink that quickly anyway.
   const [bootTyped, setBootTyped] = useState('')
   useEffect(() => {
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (reduce) {
+    if (disableHeavyFx) {
       setBootTyped(BOOT_LINE)
       return
     }
@@ -164,16 +168,22 @@ export function Intro() {
       if (i >= BOOT_LINE.length) clearInterval(t)
     }, 55)
     return () => clearInterval(t)
-  }, [])
+  }, [disableHeavyFx])
 
-  // slow frame counter for bottom HUD (10 fps is plenty)
+  // slow frame counter for bottom HUD (10 fps desktop / 5 fps mobile).
+  // Drives StabilityMeter sine wave + GlitchNum tick. Halving on mobile
+  // halves React re-renders for the HUD subtree on phones.
   const [frame, setFrame] = useState(0)
   useEffect(() => {
-    const t = setInterval(() => setFrame((n) => (n + 1) % 10000), 100)
+    if (reduceMotion) return
+    const t = setInterval(() => setFrame((n) => (n + 1) % 10000), isMobile ? 200 : 100)
     return () => clearInterval(t)
-  }, [])
+  }, [isMobile, reduceMotion])
 
   useEffect(() => {
+    // Skip mouse-tracked spotlight on mobile — the radial-gradient repaint
+    // costs frames during scroll and there's no cursor to follow anyway.
+    if (isMobile) return
     const el = sectionRef.current
     if (!el) return
     const handler = (e: MouseEvent) => {
@@ -191,7 +201,7 @@ export function Intro() {
       el.removeEventListener('mousemove', handler)
       el.removeEventListener('mouseleave', leave)
     }
-  }, [mouseX, mouseY])
+  }, [mouseX, mouseY, isMobile])
 
   return (
     <section
@@ -221,46 +231,51 @@ export function Intro() {
       {/* === Shooting stars: bright diagonal streaks === */}
       <MeteorField />
 
-      {/* floating micro-particles */}
-      <div
-        aria-hidden
-        className="absolute inset-0 pointer-events-none overflow-hidden"
-      >
-        {[
-          { left: '12%', top: '22%', size: 4, color: 'bg-accent/60', dur: 7, delay: 0 },
-          { left: '82%', top: '18%', size: 3, color: 'bg-lime/70', dur: 9, delay: 1.2 },
-          { left: '28%', top: '72%', size: 5, color: 'bg-amber/50', dur: 8, delay: 2.1 },
-          { left: '62%', top: '58%', size: 2, color: 'bg-electric/70', dur: 10, delay: 0.6 },
-          { left: '90%', top: '68%', size: 3, color: 'bg-accent/50', dur: 11, delay: 3 },
-          { left: '5%', top: '52%', size: 2, color: 'bg-lime/60', dur: 12, delay: 1.8 },
-          { left: '48%', top: '12%', size: 3, color: 'bg-amber/60', dur: 9, delay: 2.8 },
-          { left: '72%', top: '82%', size: 4, color: 'bg-accent/40', dur: 13, delay: 0.4 },
-        ].map((p, i) => (
-          <motion.span
-            key={i}
-            className={`absolute rounded-full ${p.color}`}
-            style={{
-              left: p.left,
-              top: p.top,
-              width: p.size,
-              height: p.size,
-              boxShadow: '0 0 12px currentColor',
-            }}
-            animate={{
-              y: [0, -24, 0],
-              x: [0, i % 2 === 0 ? 12 : -12, 0],
-              opacity: [0.3, 0.9, 0.3],
-              scale: [0.8, 1.2, 0.8],
-            }}
-            transition={{
-              duration: p.dur,
-              delay: p.delay,
-              repeat: Infinity,
-              ease: 'easeInOut',
-            }}
-          />
-        ))}
-      </div>
+      {/* floating micro-particles — desktop-only. 8 infinite framer-motion
+          loops compositing 4 properties each = 32 active animation tracks
+          that the browser keeps repainting. On mobile they barely register
+          visually but add real GPU load during scroll. */}
+      {!disableHeavyFx && (
+        <div
+          aria-hidden
+          className="absolute inset-0 pointer-events-none overflow-hidden"
+        >
+          {[
+            { left: '12%', top: '22%', size: 4, color: 'bg-accent/60', dur: 7, delay: 0 },
+            { left: '82%', top: '18%', size: 3, color: 'bg-lime/70', dur: 9, delay: 1.2 },
+            { left: '28%', top: '72%', size: 5, color: 'bg-amber/50', dur: 8, delay: 2.1 },
+            { left: '62%', top: '58%', size: 2, color: 'bg-electric/70', dur: 10, delay: 0.6 },
+            { left: '90%', top: '68%', size: 3, color: 'bg-accent/50', dur: 11, delay: 3 },
+            { left: '5%', top: '52%', size: 2, color: 'bg-lime/60', dur: 12, delay: 1.8 },
+            { left: '48%', top: '12%', size: 3, color: 'bg-amber/60', dur: 9, delay: 2.8 },
+            { left: '72%', top: '82%', size: 4, color: 'bg-accent/40', dur: 13, delay: 0.4 },
+          ].map((p, i) => (
+            <motion.span
+              key={i}
+              className={`absolute rounded-full ${p.color}`}
+              style={{
+                left: p.left,
+                top: p.top,
+                width: p.size,
+                height: p.size,
+                boxShadow: '0 0 12px currentColor',
+              }}
+              animate={{
+                y: [0, -24, 0],
+                x: [0, i % 2 === 0 ? 12 : -12, 0],
+                opacity: [0.3, 0.9, 0.3],
+                scale: [0.8, 1.2, 0.8],
+              }}
+              transition={{
+                duration: p.dur,
+                delay: p.delay,
+                repeat: Infinity,
+                ease: 'easeInOut',
+              }}
+            />
+          ))}
+        </div>
+      )}
 
       {/* HUD corner brackets */}
       <HudCorners />
@@ -1019,6 +1034,11 @@ type Trace = {
 }
 
 function CircuitField() {
+  // 10 traces × 2 SMIL <animateMotion> circles + 10 opacity <animate> tags =
+  // ~30 concurrent SMIL animations. SMIL is GPU-cheap on desktop but causes
+  // measurable jank on mid-range Android during scroll. Hide entirely on
+  // mobile and for prefers-reduced-motion (was previously unconditional).
+  const { disableHeavyFx } = useFxLevel()
   const traces: Trace[] = useMemo(() => {
     const palette = [
       'hsl(var(--accent))',
@@ -1047,6 +1067,8 @@ function CircuitField() {
       delay: (i * 0.7) % 5,
     }))
   }, [])
+
+  if (disableHeavyFx) return null
 
   return (
     <svg
@@ -1169,20 +1191,15 @@ type Meteor = {
 }
 
 function MeteorField() {
-  const [reduce, setReduce] = useState(false)
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReduce(mq.matches)
-    const onChange = () => setReduce(mq.matches)
-    mq.addEventListener?.('change', onChange)
-    return () => mq.removeEventListener?.('change', onChange)
-  }, [])
+  // Desktop-only. Streaming geometry + state churn (spawn → setTimeout →
+  // splice) every 2.2s is wasted work on phones where the meteors are tiny
+  // and barely visible against the busy hero. Mirrors LightningField's gate.
+  const { disableHeavyFx } = useFxLevel()
   const [meteors, setMeteors] = useState<Meteor[]>([])
   const idRef = useRef(0)
 
   useEffect(() => {
-    if (reduce) return
+    if (disableHeavyFx) return
     const spawn = () => {
       const id = idRef.current++
       const palette = [
@@ -1213,9 +1230,9 @@ function MeteorField() {
       clearTimeout(first)
       clearInterval(iv)
     }
-  }, [reduce])
+  }, [disableHeavyFx])
 
-  if (reduce) return null
+  if (disableHeavyFx) return null
   return (
     <div
       aria-hidden
@@ -1256,15 +1273,11 @@ function MeteorField() {
 // ============================================================
 
 function LightningField() {
-  const [reduce, setReduce] = useState(false)
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReduce(mq.matches)
-    const onChange = () => setReduce(mq.matches)
-    mq.addEventListener?.('change', onChange)
-    return () => mq.removeEventListener?.('change', onChange)
-  }, [])
+  // Lightning is desktop-only — fractal generation + 4 SVG path layers per
+  // bolt + 900ms ticker is too much for mid-range phones, and the dramatic
+  // strikes read as visual noise alongside the rest of the hero on a small
+  // screen. Falls back identically for prefers-reduced-motion.
+  const { disableHeavyFx } = useFxLevel()
 
   const [bolts, setBolts] = useState<
     Array<{ id: number; d: string; color: string; duration: number }>
@@ -1272,7 +1285,7 @@ function LightningField() {
   const idRef = useRef(0)
 
   useEffect(() => {
-    if (reduce) return
+    if (disableHeavyFx) return
     // Midpoint-displacement subdivision — classic "fractal lightning"
     // algorithm. Repeatedly splits each segment and jitters the midpoint
     // perpendicular to the segment direction. Produces the irregular,
@@ -1387,9 +1400,9 @@ function LightningField() {
       clearTimeout(first)
       clearInterval(interval)
     }
-  }, [reduce])
+  }, [disableHeavyFx])
 
-  if (reduce) return null
+  if (disableHeavyFx) return null
 
   return (
     <svg

--- a/src/components/NomadLife.tsx
+++ b/src/components/NomadLife.tsx
@@ -18,6 +18,7 @@ import {
 import type { LucideIcon } from 'lucide-react'
 import { AnimatedNumber } from './ui/AnimatedNumber'
 import { trackEvent } from '../utils/analytics'
+import { useFxLevel } from '../hooks/useFxLevel'
 
 // ============================================================
 // DATA — cities with real lat/lng + global flight plan
@@ -405,7 +406,15 @@ function useLiveTime() {
 // ============================================================
 
 export function NomadLife() {
+  // `reduceMotion` is the strict a11y signal — kills path animations and
+  // shows the static parked-plane fallback. `lite` is the broader "skip
+  // expensive decorative bg fx" signal — true for either reduced-motion
+  // OR sub-768px viewports. We pass both so FlightRadar can show its
+  // central plane animation on mobile (the centerpiece) while suppressing
+  // the dozens of stars / clouds / radar sweep / beacon pings around it.
   const reduceMotion = !!useReducedMotion()
+  const { isMobile } = useFxLevel()
+  const lite = reduceMotion || isMobile
   return (
     <section
       id="nomad-section"
@@ -437,7 +446,7 @@ export function NomadLife() {
 
         {/* ===================== FLIGHT RADAR ===================== */}
         <div className="mt-10 md:mt-12">
-          <FlightRadar reduceMotion={reduceMotion} />
+          <FlightRadar reduceMotion={reduceMotion} lite={lite} />
         </div>
 
         {/* ===================== BOARDING PASSES ===================== */}
@@ -552,8 +561,11 @@ function SectionDivider({ title, meta }: { title: string; meta?: string }) {
 // ============================================================
 
 function FloatingPlaneDecor() {
-  const reduceMotion = useReducedMotion()
-  if (reduceMotion) return null
+  // Two infinite framer-motion translations across the full section.
+  // Decorative-only; on mobile/reduce we skip them (the section's centerpiece
+  // is the FlightRadar card, not background plane silhouettes).
+  const { disableHeavyFx } = useFxLevel()
+  if (disableHeavyFx) return null
   return (
     <>
       <motion.span
@@ -592,12 +604,21 @@ function FloatingPlaneDecor() {
 // FlightRadar — world-map centerpiece with dotted continents
 // ============================================================
 
-function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
+function FlightRadar({
+  reduceMotion,
+  lite,
+}: {
+  reduceMotion: boolean
+  // `lite` = drop heavy decorative SVG fx (mobile or reduce-motion). The
+  // central plane animation along the active route still renders unless
+  // `reduceMotion` is set — that one is the section's whole point.
+  lite: boolean
+}) {
   const current = CITIES.find((c) => c.current)!
   const currentProj = project(current.lng, current.lat)
   const livePlanePath = compoundArcPath(ACTIVE_EDGES, 0.32)
 
-  // ===== 3D mouse tilt =====
+  // ===== 3D mouse tilt — desktop only ===
   const cardRef = useRef<HTMLDivElement | null>(null)
   const mx = useMotionValue(0)
   const my = useMotionValue(0)
@@ -620,11 +641,14 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
   const latGridLines = [-60, -30, 0, 30, 60]
 
   // ===== Starfield / twinkles (memoized for stable positions) =====
-  // 40 stars is plenty of density for twinkle effect while keeping SMIL
-  // animation count low on mobile (each star is a concurrent <animate>).
+  // Desktop: 40 stars (each gets a concurrent SMIL <animate> opacity tween).
+  // Mobile/reduce: 12 stars and we drop the SMIL twinkle entirely below.
+  // Going from ~40 SMIL animations to 0 is the single biggest paint-cost
+  // win in this section on phones.
+  const STAR_COUNT = lite ? 12 : 40
   const stars = useMemo(
     () =>
-      Array.from({ length: 40 }).map((_, i) => ({
+      Array.from({ length: STAR_COUNT }).map((_, i) => ({
         id: i,
         x: Math.random() * 100,
         y: Math.random() * 50,
@@ -632,7 +656,7 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
         dur: 1.5 + Math.random() * 3.5,
         delay: Math.random() * 5,
       })),
-    [],
+    [STAR_COUNT],
   )
 
   // ===== Drifting clouds =====
@@ -673,7 +697,10 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
       viewport={{ once: true, margin: '-80px' }}
       transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
       onMouseMove={(e) => {
-        if (reduceMotion) return
+        // Skip on lite (mobile/reduce) — phantom touchscreen mousemove
+        // events would otherwise trigger spring re-computation for a
+        // tilt the user can't perceive.
+        if (lite) return
         const rect = cardRef.current?.getBoundingClientRect()
         if (!rect) return
         mx.set((e.clientX - rect.left) / rect.width - 0.5)
@@ -696,7 +723,7 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
         <span className="font-mono text-[10.5px] text-white/75 ml-2 truncate">
           globe.radar · live.feed · v2.{new Date().getFullYear()}
         </span>
-        <ChromeLive reduceMotion={reduceMotion} />
+        <ChromeLive lite={lite} />
       </div>
 
       {/* 3D tilted map area */}
@@ -769,7 +796,7 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
                 fill="hsl(var(--ink))"
                 opacity="0.45"
               >
-                {!reduceMotion && (
+                {!lite && (
                   <animate
                     attributeName="opacity"
                     values="0.12;0.8;0.12"
@@ -783,7 +810,7 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
           </g>
 
           {/* ===== shooting-star streaks ===== */}
-          {!reduceMotion && (
+          {!lite && (
             <g pointerEvents="none">
               <line
                 x1="0"
@@ -929,8 +956,10 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
             })}
           </motion.g>
 
-          {/* ===== drifting cloud layer (passes over the globe) ===== */}
-          {!reduceMotion &&
+          {/* ===== drifting cloud layer (passes over the globe) — desktop only.
+              5 SMIL animateTransform loops at 60–116s each; the slow drift
+              barely registers on a phone-sized map but still costs paint. */}
+          {!lite &&
             clouds.map((c) => (
               <g key={`cloud-${c.id}`} pointerEvents="none" opacity={c.opacity}>
                 <g transform={`translate(0 ${c.y}) scale(${c.scale})`}>
@@ -949,8 +978,11 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
               </g>
             ))}
 
-          {/* ===== radar sweep at current city ===== */}
-          {!reduceMotion && (
+          {/* ===== radar sweep at current city — desktop only.
+              Continuous 360° SMIL rotation with a gradient cone + bright
+              leading edge is GPU-cheap on desktop but on phones the
+              constant repaint costs frames during scroll. */}
+          {!lite && (
             <g
               transform={`translate(${currentProj.x} ${currentProj.y})`}
               pointerEvents="none"
@@ -1095,8 +1127,8 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
             const anchor = c.labelAnchor ?? 'start'
             return (
               <g key={c.code}>
-                {/* beacon city ping (staggered) */}
-                {isBeacon && !isCurrent && !reduceMotion && (
+                {/* beacon city ping (staggered) — desktop only */}
+                {isBeacon && !isCurrent && !lite && (
                   <circle
                     cx={p.x}
                     cy={p.y}
@@ -1124,8 +1156,9 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
                     />
                   </circle>
                 )}
-                {/* pulse rings on current */}
-                {isCurrent && !reduceMotion && (
+                {/* pulse rings on current — keep on desktop only; mobile
+                    keeps the static accent dot which still reads as "here" */}
+                {isCurrent && !lite && (
                   <>
                     <circle
                       cx={p.x}
@@ -1245,8 +1278,11 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
             )
           })}
 
-          {/* ===== contrail — staggered particle chain BEHIND the plane ===== */}
-          {!reduceMotion && (
+          {/* ===== contrail — staggered particle chain BEHIND the plane.
+              Desktop only: 4 SMIL animateMotion particles tracing the same
+              path. On mobile the plane itself still flies — it just doesn't
+              trail glowy dots. ===== */}
+          {!lite && (
             <g pointerEvents="none">
               {[
                 { beg: -1.8, op: 0.55, r: 0.28 },
@@ -1272,27 +1308,37 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
             </g>
           )}
 
-          {/* ===== live plane flying the active route ===== */}
+          {/* ===== live plane flying the active route =====
+              Desktop: pulsing halo + bright core + detailed silhouette
+                (3 concurrent animateMotion + 1 animate on radius).
+              Mobile: just the silhouette. The plane is the section's
+                whole visual hook so we still fly it — we just stop
+                running 3 SMIL tracks for what's effectively one moving
+                point on a phone-sized map. */}
           {!reduceMotion && (
             <g>
-              {/* pulsing halo */}
-              <circle r="1.4" fill="hsl(var(--amber))" opacity="0.22">
-                <animate
-                  attributeName="r"
-                  values="1.2;1.8;1.2"
-                  dur="1.4s"
-                  repeatCount="indefinite"
-                />
-                <animateMotion dur="14s" begin="-2s" repeatCount="indefinite">
-                  <mpath href="#active-route-path" />
-                </animateMotion>
-              </circle>
-              {/* bright core dot */}
-              <circle r="0.4" fill="hsl(var(--amber))">
-                <animateMotion dur="14s" begin="-2s" repeatCount="indefinite">
-                  <mpath href="#active-route-path" />
-                </animateMotion>
-              </circle>
+              {!lite && (
+                <>
+                  {/* pulsing halo */}
+                  <circle r="1.4" fill="hsl(var(--amber))" opacity="0.22">
+                    <animate
+                      attributeName="r"
+                      values="1.2;1.8;1.2"
+                      dur="1.4s"
+                      repeatCount="indefinite"
+                    />
+                    <animateMotion dur="14s" begin="-2s" repeatCount="indefinite">
+                      <mpath href="#active-route-path" />
+                    </animateMotion>
+                  </circle>
+                  {/* bright core dot */}
+                  <circle r="0.4" fill="hsl(var(--amber))">
+                    <animateMotion dur="14s" begin="-2s" repeatCount="indefinite">
+                      <mpath href="#active-route-path" />
+                    </animateMotion>
+                  </circle>
+                </>
+              )}
               {/* detailed plane silhouette — rotates to match heading */}
               <g>
                 <use href="#plane-icon" />
@@ -1316,8 +1362,11 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
             </g>
           )}
 
-          {/* ===== secondary ambient planes — trimmed from 5 to 3 for mobile perf ===== */}
-          {!reduceMotion &&
+          {/* ===== secondary ambient planes — desktop only.
+              3 routes × 2 SMIL animateMotion (halo + core) = 6 concurrent
+              path-traversal animations. Killing these on mobile is a clean
+              win — they're tiny green dots in the periphery anyway. ===== */}
+          {!lite &&
             [
               ['TPE', 'TYO'],
               ['BLI', 'SYD'],
@@ -1375,8 +1424,11 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
           }}
         />
 
-        {/* ===== slow vertical scan sweep ===== */}
-        {!reduceMotion && (
+        {/* ===== slow vertical scan sweep — desktop only.
+            Full-height gradient div translating top→bottom on Infinity loop.
+            On mobile this triggers a full-section repaint every 10.5s
+            cycle. Skip. */}
+        {!lite && (
           <motion.div
             aria-hidden
             className="absolute inset-0 pointer-events-none mix-blend-screen"
@@ -1412,10 +1464,11 @@ function FlightRadar({ reduceMotion }: { reduceMotion: boolean }) {
         </div>
 
         {/* top-right: live speed + altitude + uplink */}
-        <CockpitHUD reduceMotion={reduceMotion} />
+        <CockpitHUD lite={lite} />
 
         {/* bottom-left: compass rose + HDG + DIST (self-owns its 650ms tick) */}
         <NavHUD
+          lite={lite}
           reduceMotion={reduceMotion}
           routeCount={ROUTE_EDGES.length}
           cityCount={CITIES.length}
@@ -1617,13 +1670,17 @@ function PassportStampsStrip({
 // re-rendering every tick. Big perf win on mobile.
 // ============================================================
 
-function ChromeLive({ reduceMotion }: { reduceMotion: boolean }) {
+function ChromeLive({ lite }: { lite: boolean }) {
+  // `lite` (mobile or reduce-motion) → freeze readouts at the initial
+  // snapshot. The 1.2s altitude tick and 30s UTC tick each fire setState
+  // which forces a re-render of the parent's chrome row; skipping them
+  // on phones removes ~60 React renders/min for no visible benefit.
   const [state, setState] = useState(() => ({
     alt: 35100,
     utc: new Date().toISOString().slice(11, 16),
   }))
   useEffect(() => {
-    if (reduceMotion) return
+    if (lite) return
     const a = setInterval(() => {
       setState((s) => ({
         ...s,
@@ -1639,7 +1696,7 @@ function ChromeLive({ reduceMotion }: { reduceMotion: boolean }) {
       clearInterval(a)
       clearInterval(b)
     }
-  }, [reduceMotion])
+  }, [lite])
   return (
     <span className="ml-auto flex items-center gap-3 font-mono text-[10px] text-white/55">
       <span className="inline-flex items-center gap-1.5">
@@ -1658,10 +1715,13 @@ function ChromeLive({ reduceMotion }: { reduceMotion: boolean }) {
   )
 }
 
-function CockpitHUD({ reduceMotion }: { reduceMotion: boolean }) {
+function CockpitHUD({ lite }: { lite: boolean }) {
+  // 900ms tick on mobile = ~67 setState/min for two integer readouts;
+  // the resulting "live" feel is invisible on phone (small text, fast
+  // scroll-past). Static is fine.
   const [r, setR] = useState({ spd: 864, alt: 35100 })
   useEffect(() => {
-    if (reduceMotion) return
+    if (lite) return
     const t = setInterval(() => {
       setR({
         spd: Math.round(
@@ -1673,7 +1733,7 @@ function CockpitHUD({ reduceMotion }: { reduceMotion: boolean }) {
       })
     }, 900)
     return () => clearInterval(t)
-  }, [reduceMotion])
+  }, [lite])
   return (
     <div className="absolute top-3 right-3 md:top-4 md:right-4 font-mono text-[10px] text-ink-soft bg-background/75 backdrop-blur px-2 py-1 rounded border border-border/70">
       <div className="flex items-center gap-2">
@@ -1703,17 +1763,22 @@ function CockpitHUD({ reduceMotion }: { reduceMotion: boolean }) {
 }
 
 function NavHUD({
+  lite,
   reduceMotion,
   routeCount,
   cityCount,
 }: {
+  lite: boolean
   reduceMotion: boolean
   routeCount: number
   cityCount: number
 }) {
+  // Same shape as CockpitHUD — `lite` freezes the tick. We still pass
+  // `reduceMotion` separately to CompassRose so the spring-rotated needle
+  // respects strict a11y intent.
   const [r, setR] = useState({ hdg: 292, dist: 184302 })
   useEffect(() => {
-    if (reduceMotion) return
+    if (lite) return
     const t = setInterval(() => {
       setR((prev) => ({
         hdg: Math.round(((292 + Math.sin(Date.now() / 4000) * 5) + 360) % 360),
@@ -1721,7 +1786,7 @@ function NavHUD({
       }))
     }, 900)
     return () => clearInterval(t)
-  }, [reduceMotion])
+  }, [lite])
   return (
     <div className="absolute bottom-3 left-3 md:bottom-4 md:left-4 flex items-end gap-2">
       <CompassRose hdg={r.hdg} reduceMotion={reduceMotion} />

--- a/src/components/TechToolbelt.tsx
+++ b/src/components/TechToolbelt.tsx
@@ -19,6 +19,7 @@ import {
 import type { LucideIcon } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Marquee } from './ui/Marquee'
+import { useFxLevel } from '../hooks/useFxLevel'
 
 type Accent = 'accent' | 'lime' | 'electric'
 
@@ -530,15 +531,22 @@ function SkillHeatmap({
   const mx = useMotionValue(50)
   const my = useMotionValue(50)
   const bg = useMotionTemplate`radial-gradient(500px circle at ${mx}% ${my}%, hsl(var(--accent) / 0.08), transparent 50%)`
+  // Skip mousemove handler on mobile — touchscreens fire phantom mousemove
+  // events on tap that retrigger the radial-gradient repaint for nothing.
+  const { isMobile } = useFxLevel()
 
   return (
     <div
       ref={ref}
-      onMouseMove={(e) => {
-        const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
-        mx.set(((e.clientX - r.left) / r.width) * 100)
-        my.set(((e.clientY - r.top) / r.height) * 100)
-      }}
+      onMouseMove={
+        isMobile
+          ? undefined
+          : (e) => {
+              const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+              mx.set(((e.clientX - r.left) / r.width) * 100)
+              my.set(((e.clientY - r.top) / r.height) * 100)
+            }
+      }
       className="relative border-b border-border bg-gradient-to-br from-background via-surface/20 to-background px-5 md:px-6 py-5 overflow-hidden"
     >
       {/* scanline overlay */}
@@ -603,7 +611,7 @@ function SkillHeatmap({
                 style={{ backgroundColor: col }}
                 aria-label={`${s.name}, ${s.years || 0} years${s.live ? ', live' : ''}`}
               >
-                {s.live && (
+                {s.live && !isMobile && (
                   <motion.span
                     aria-hidden
                     className="absolute inset-0 rounded-[4px]"
@@ -644,6 +652,10 @@ function ProcessTable({ stack, index }: { stack: Stack; index: number }) {
   const mx = useMotionValue(0)
   const my = useMotionValue(0)
   const spot = useMotionTemplate`radial-gradient(500px circle at ${mx}% ${my}%, ${cls.glow}, transparent 55%)`
+  // Mobile: skip mouse spotlight (touchscreens fire phantom mousemove on tap)
+  // and skip the per-row live-shimmer infinite loop. With ~60 live rows the
+  // shimmer alone was running 60 concurrent animations every frame.
+  const { isMobile } = useFxLevel()
 
   const total = stack.groups.reduce((n, g) => n + g.items.length, 0)
   const live = stack.groups.reduce(
@@ -654,12 +666,16 @@ function ProcessTable({ stack, index }: { stack: Stack; index: number }) {
   return (
     <motion.div
       ref={ref}
-      onMouseMove={(e) => {
-        if (!ref.current) return
-        const r = ref.current.getBoundingClientRect()
-        mx.set(((e.clientX - r.left) / r.width) * 100)
-        my.set(((e.clientY - r.top) / r.height) * 100)
-      }}
+      onMouseMove={
+        isMobile
+          ? undefined
+          : (e) => {
+              if (!ref.current) return
+              const r = ref.current.getBoundingClientRect()
+              mx.set(((e.clientX - r.left) / r.width) * 100)
+              my.set(((e.clientY - r.top) / r.height) * 100)
+            }
+      }
       layout
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -739,6 +755,7 @@ function ProcessTable({ stack, index }: { stack: Stack; index: number }) {
                   accent={stack.accent}
                   pid={(gi * 100 + i + 1).toString().padStart(3, '0')}
                   rowIndex={gi * 10 + i}
+                  lite={isMobile}
                 />
               ))}
             </div>
@@ -774,11 +791,13 @@ function ProcessRow({
   accent,
   pid,
   rowIndex,
+  lite = false,
 }: {
   skill: Skill
   accent: Accent
   pid: string
   rowIndex: number
+  lite?: boolean
 }) {
   const cls = ACCENT_TOKEN[accent]
   const loadPct = Math.min((skill.years || 1) / 11, 1) * 100
@@ -846,9 +865,11 @@ function ProcessRow({
         {skill.live ? (
           <>
             <span className="relative flex h-1.5 w-1.5">
-              <span
-                className={`absolute inline-flex h-full w-full rounded-full ${cls.dot} opacity-75 animate-ping`}
-              />
+              {!lite && (
+                <span
+                  className={`absolute inline-flex h-full w-full rounded-full ${cls.dot} opacity-75 animate-ping`}
+                />
+              )}
               <span
                 className={`relative inline-flex h-1.5 w-1.5 rounded-full ${cls.dot}`}
               />
@@ -878,7 +899,7 @@ function ProcessRow({
           }}
           style={{ opacity: skill.years && skill.years >= 3 ? 1 : 0.55 }}
         />
-        {skill.live && (
+        {skill.live && !lite && (
           <motion.span
             aria-hidden
             className="absolute top-0 bottom-0 w-6 bg-gradient-to-r from-transparent via-white/40 to-transparent"

--- a/src/components/TravelStories.tsx
+++ b/src/components/TravelStories.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import type { BlogPost } from '../types/data'
 import { Link } from 'react-router-dom'
+import { useFxLevel } from '../hooks/useFxLevel'
 
 interface TravelStoriesProps {
   stories: BlogPost[]
@@ -174,6 +175,10 @@ function FeaturedDispatch({ post, index }: { post: BlogPost; index: number }) {
   const meta = stableMeta(post.slug)
   const ref = useRef<HTMLDivElement>(null)
   const reduce = useReducedMotion()
+  const { isMobile } = useFxLevel()
+  // `lite` = mobile or reduce-motion. Tilt + decorative orbit get dropped;
+  // the card itself still mounts and reveals normally.
+  const lite = isMobile || reduce
 
   // Tilt on mouse move
   const mx = useMotionValue(0.5)
@@ -183,7 +188,7 @@ function FeaturedDispatch({ post, index }: { post: BlogPost; index: number }) {
   const rotY = useSpring(useTransform(mx, [0, 1], [-5, 5]), spring)
 
   const handleMove = (e: React.MouseEvent) => {
-    if (!ref.current || reduce) return
+    if (!ref.current || lite) return
     const rect = ref.current.getBoundingClientRect()
     mx.set((e.clientX - rect.left) / rect.width)
     my.set((e.clientY - rect.top) / rect.height)
@@ -293,16 +298,18 @@ function FeaturedDispatch({ post, index }: { post: BlogPost; index: number }) {
                 viewport={{ once: true }}
                 transition={{ duration: 1.8, delay: 0.3 }}
               />
-              <motion.circle
-                r="2.5"
-                fill="hsl(var(--accent))"
-                initial={{ offsetDistance: '0%' }}
-                animate={reduce ? undefined : { offsetDistance: ['0%', '100%'] }}
-                transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
-                style={{
-                  offsetPath: "path('M 0 60 Q 100 20, 200 45 T 400 30')",
-                }}
-              />
+              {!lite && (
+                <motion.circle
+                  r="2.5"
+                  fill="hsl(var(--accent))"
+                  initial={{ offsetDistance: '0%' }}
+                  animate={{ offsetDistance: ['0%', '100%'] }}
+                  transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
+                  style={{
+                    offsetPath: "path('M 0 60 Q 100 20, 200 45 T 400 30')",
+                  }}
+                />
+              )}
             </svg>
           </div>
 
@@ -448,6 +455,7 @@ function DispatchConsole({ count }: { count: number }) {
   const now = useLiveTime()
   const utc = now.toISOString().slice(11, 16) // HH:MM UTC
   const reduce = useReducedMotion()
+  const { isMobile } = useFxLevel()
 
   return (
     <div className="relative flex flex-wrap items-center gap-x-5 gap-y-2 font-mono text-[10px] tracking-[0.22em] uppercase text-ink-soft mb-4">
@@ -467,9 +475,11 @@ function DispatchConsole({ count }: { count: number }) {
         <Stamp className="w-3 h-3" />
         {count} dispatches on wire
       </span>
-      {!reduce && (
+      {!reduce && !isMobile && (
         <span className="hidden md:inline-flex items-center gap-0.5">
-          {/* frequency bars */}
+          {/* frequency bars — desktop only. Wrapper was already `hidden md:`,
+              but framer-motion still ticks display:none elements on rAF, so
+              skipping the render entirely on mobile is the actual win. */}
           {Array.from({ length: 10 }).map((_, i) => (
             <motion.span
               key={i}

--- a/src/hooks/useFxLevel.ts
+++ b/src/hooks/useFxLevel.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * useFxLevel — single source of truth for "should I run heavy decorative
+ * animations" decisions across the site.
+ *
+ * Returns three signals:
+ *   - reduceMotion: user has `prefers-reduced-motion: reduce`
+ *   - isMobile:     viewport is below the md breakpoint (<768px)
+ *   - disableHeavyFx: true if EITHER of the above. This is the flag most
+ *     decorative code should gate on — kills the work for both touch
+ *     phones (perf) and a11y users (preference) in one check.
+ *
+ * Why a hook (not a constant): both can change at runtime. A user can
+ * resize their window, rotate their phone, or toggle the system reduce-
+ * motion setting. We listen to MediaQueryList change events so components
+ * re-render with fresh values.
+ *
+ * SSR-safe: starts with `disableHeavyFx: true` (the conservative default —
+ * no heavy animations until we're sure the client is a desktop with no
+ * reduce-motion preference). Hydrates to the real values on mount.
+ */
+export function useFxLevel() {
+  const [state, setState] = useState(() => ({
+    reduceMotion: true,
+    isMobile: true,
+    disableHeavyFx: true,
+  }))
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const rmq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const dmq = window.matchMedia('(min-width: 768px)')
+
+    const sync = () => {
+      const reduceMotion = rmq.matches
+      const isMobile = !dmq.matches
+      setState({
+        reduceMotion,
+        isMobile,
+        disableHeavyFx: reduceMotion || isMobile,
+      })
+    }
+    sync()
+
+    rmq.addEventListener?.('change', sync)
+    dmq.addEventListener?.('change', sync)
+    return () => {
+      rmq.removeEventListener?.('change', sync)
+      dmq.removeEventListener?.('change', sync)
+    }
+  }, [])
+
+  return state
+}


### PR DESCRIPTION
## Summary

Above-the-fold and the "nomading across asia" section felt laggy on phones because multiple sections were running dozens of concurrent infinite animations (framer-motion + SMIL) that have no visual payoff at small viewport with touch input.

This change introduces a shared `useFxLevel()` hook returning three reactive signals (`reduceMotion`, `isMobile`, `disableHeavyFx`) and uses them to gate decorative animations across the home page. Desktop experience is unchanged.

## Per-section changes

- **Intro** — LightningField / MeteorField / CircuitField / floating particles all gated; boot typewriter emits the full line instantly on lite; frame counter throttled (100/200ms); mousemove spotlight skipped on mobile.
- **NomadLife / FlightRadar** — two-tier gate: the central plane keeps animating on mobile (it's the centerpiece) but stars (40 → 12), shooting stars, clouds, radar sweep, beacon pings, contrails, secondary ambient planes, vertical scan sweep, plane halo, 3D tilt, and HUD intervals are all dropped on lite. FloatingPlaneDecor skipped entirely.
- **TechToolbelt** — SkillHeatmap per-tile infinite pulse (~30 concurrent loops) + ProcessRow `.live` shimmer (~60 concurrent) + per-row `animate-ping` indicators all gated on mobile. ProcessTable mouse-spotlight gated.
- **ContactSection** — Waveform reduced 40 → 20 bars on mobile.
- **TravelStories** — DispatchConsole 10 freq bars skipped on mobile (wrapper was `hidden md:` but framer-motion still ticks display:none elements). FeaturedDispatch orbit-circle infinite animation + 3D tilt gated on lite.

## Test plan

- [ ] Open home page on a real phone (or DevTools mobile emulator with CPU 4× throttle) — above-the-fold + FlightRadar should now scroll smoothly
- [ ] Confirm desktop still shows all decorative animations as before
- [ ] Confirm `prefers-reduced-motion: reduce` (system setting) drops the same animations on desktop
- [ ] Resize across 768px breakpoint — animations should add/drop reactively (the hook listens to matchMedia change)
- [ ] FlightRadar's central plane still animates on mobile (only decorative layers should drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)